### PR TITLE
Fix 타이틀, 컨텐츠 입력시, 자음 모음 분리되는 이슈 수정

### DIFF
--- a/lib/screen/edit_calendar/widget/edit_content.dart
+++ b/lib/screen/edit_calendar/widget/edit_content.dart
@@ -26,21 +26,8 @@ class _EditContentState extends ConsumerState<EditContent> {
     super.dispose();
   }
 
-  /// 콘텐트 상태값 리스너
-  void addContentListener() {
-    ref.listen(editCalendarProvider.select((value) => value.content),
-        (previous, next) {
-      contentController.text = next ?? '';
-      contentController.selection = TextSelection(
-          baseOffset: contentController.text.length,
-          extentOffset: contentController.text.length);
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
-    addContentListener();
-
     return Padding(
       padding: const EdgeInsets.all(16),
       child: Column(

--- a/lib/screen/edit_calendar/widget/edit_title.dart
+++ b/lib/screen/edit_calendar/widget/edit_title.dart
@@ -26,21 +26,8 @@ class _EditTitleState extends ConsumerState<EditTitle> {
     super.dispose();
   }
 
-  /// 타이틀 상태값 리스너 등록
-  void addTitleListener() {
-    ref.listen(editCalendarProvider.select((value) => value.title),
-        (previous, next) {
-      titleController.text = next;
-      titleController.selection = TextSelection(
-          baseOffset: titleController.text.length,
-          extentOffset: titleController.text.length);
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
-    addTitleListener();
-
     return Padding(
       padding: const EdgeInsets.all(16.0),
       child: Column(


### PR DESCRIPTION
## 작업 내용
- 안드로이드 기기에서 타이틀, 컨텐츠 입력시 자음 모음 분리되어 입력되는 이슈 수정
  - 텍스트필드, 프로바이더가 서로 listen 하게 되면서 위젯이 리빌드 되는 이슈
## 작업 링크

## 체크 사항